### PR TITLE
Export CurrentGitTagRevision and bump version to 0.1.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-meteor-tutorials-infrastructure",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Angular-Meteor's tutorials infrastructure",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/current-tutorial.ts
+++ b/src/current-tutorial.ts
@@ -5,11 +5,13 @@ export class ActivatedTutorial {
   public tutorial: Subject<TutorialDefinition>;
   public step: Subject<TutorialStep>;
   public steps: Subject<TutorialStep[]>;
+  public gitTagRevision: Subject<string>;
 
   constructor() {
     this.step = new Subject<TutorialStep>();
     this.tutorial = new Subject<TutorialDefinition>();
     this.steps = new Subject<TutorialStep[]>();
+    this.gitTagRevision = new Subject<string>();
   }
 
   updateCurrentTutorial(tutorial: TutorialDefinition) {
@@ -22,5 +24,9 @@ export class ActivatedTutorial {
 
   updateCurrentSteps(steps: TutorialStep[]) {
     this.steps.next(steps);
+  }
+
+  updateCurrentGitTagRevision(gitTagRevision: string) {
+      this.gitTagRevision.next(gitTagRevision);
   }
 }

--- a/src/tutorial-page.component.ts
+++ b/src/tutorial-page.component.ts
@@ -40,6 +40,7 @@ export class TutorialPage implements OnInit {
       this.currentTutorial.updateCurrentTutorial(this.tutorial);
       this.currentTutorial.updateCurrentStep(this.step);
       this.currentTutorial.updateCurrentSteps(this.steps);
+      this.currentTutorial.updateCurrentGitTagRevision(data.gitTagRevision);
       let htmlContent = data.resolveData.step;
 
       this.seo.setSeoDescription(htmlContent);


### PR DESCRIPTION
This is needed to fix the tutorial order and the detection of the active tutorial. See https://github.com/Urigo/angular-meteor-docs/pull/316